### PR TITLE
Refactor executionid

### DIFF
--- a/nb_workflows/cli.py
+++ b/nb_workflows/cli.py
@@ -28,7 +28,7 @@ def cli():
     "--auto-reload", "-A", default=False, is_flag=True, help="Enable Auto reload"
 )
 @click.option(
-    "--debug", "-D", default=Config.DEBUG, is_flag=True, help="Enable Auto reload"
+    "--debug", "-D", default=False, is_flag=True, help="Enable Auto reload"
 )
 def web(host, port, workers, apps, auto_reload, debug):
     """Run web server"""
@@ -38,6 +38,7 @@ def web(host, port, workers, apps, auto_reload, debug):
     list_bp = apps.split(",")
     init_blueprints(app, list_bp)
     w = int(workers)
+    print("Debug mode: ", debug)
     app.run(host=host, port=int(port), workers=w, auto_reload=auto_reload, debug=debug)
 
 

--- a/nb_workflows/cli.py
+++ b/nb_workflows/cli.py
@@ -27,7 +27,10 @@ def cli():
 @click.option(
     "--auto-reload", "-A", default=False, is_flag=True, help="Enable Auto reload"
 )
-def web(host, port, workers, apps, auto_reload):
+@click.option(
+    "--debug", "-D", default=Config.DEBUG, is_flag=True, help="Enable Auto reload"
+)
+def web(host, port, workers, apps, auto_reload, debug):
     """Run web server"""
     # pylint: disable=import-outside-toplevel
     from nb_workflows.server import app
@@ -35,7 +38,7 @@ def web(host, port, workers, apps, auto_reload):
     list_bp = apps.split(",")
     init_blueprints(app, list_bp)
     w = int(workers)
-    app.run(host=host, port=int(port), workers=w, auto_reload=auto_reload)
+    app.run(host=host, port=int(port), workers=w, auto_reload=auto_reload, debug=debug)
 
 
 @click.command()

--- a/nb_workflows/conf.py
+++ b/nb_workflows/conf.py
@@ -20,7 +20,8 @@ class Config:
     WORKFLOW_SERVICE = os.getenv("NB_WORKFLOW_SERVICE", "http://0.0.0.0:8000")
     # MISC
     LOGLEVEL = os.getenv("NB_LOG", "INFO")
-    DEBUG = os.getenv("NB_DEBUG")
+    # None should be false, anything else true
+    DEBUG = bool(os.getenv("NB_DEBUG", None))
 
     # Folders
     BASE_PATH = os.getenv("NB_BASEPATH")

--- a/nb_workflows/workflows/entities.py
+++ b/nb_workflows/workflows/entities.py
@@ -1,0 +1,72 @@
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+
+@dataclass
+class ScheduleData:
+    """Used as generic structure when querying database"""
+
+    alias: Optional[str] = None
+    start_in_min: int = 0
+    repeat: Optional[int] = None
+    cron: Optional[str] = None
+    interval: Optional[str] = None
+    enabled: bool = True
+
+
+@dataclass
+class NBTask:
+    """
+    NBTask is the task definition. It will be executed by papermill.
+    This interface is used together with the ScheduleCron or ScheduleInterval
+    to define a job.
+
+    :param nb_name: is the name of the notebook to run
+    :param params: a dict with the params to run the specific notebook,
+    wrapper around papermill.
+    :param jobid: jobid from ScheduleModel
+    :param timeout: time in secs to wait from the start of the task
+    to mark the task as failed.
+    :param notificate: by default if the job fails it will send a
+    notification though discord,
+    but internally the task also send a notification if the user wants.
+    """
+    nb_name: str
+    params: Dict[str, Any]
+    jobid: Optional[str] = None
+    qname: str = "default"
+    timeout: int = 10800  # secs 3h default
+    notificate: bool = False
+    schedule: Optional[ScheduleData] = None
+
+
+@dataclass
+class ExecutionTask:
+    """ It will be send to task_handler, and it has the
+    configuration needed for papermill to run a specific notebook.
+    """
+    jobid: str
+    executionid: str
+    name: str
+    params: Dict[str, Any]
+    workflow: str
+    output: str
+    created_at: str
+
+
+@dataclass
+class ExecutionResult:
+    """
+    Is the result of a ExecutionTask execution.
+    """
+    executionid: str
+    jobid: str
+    name: str
+    params: Dict[str, Any]
+    input_: str
+    output_name: str
+    output_dir: str
+    error_dir: str
+    error: bool
+    elapsed_secs: float
+    created_at: str

--- a/nb_workflows/workflows/models.py
+++ b/nb_workflows/workflows/models.py
@@ -24,8 +24,8 @@ class HistoryModel(Base, SerializerMixin):
 
     id = Column(BigInteger, primary_key=True)
     jobid = Column(String(24))
-    taskid = Column(String(24))  # should be execution id
-    name = Column(String(), nullable=False)
+    executionid = Column(String(24))  # should be execution id
+    nb_name = Column(String(), nullable=False)
     result = Column(JSONB(), nullable=False)
     status = Column(Integer, index=True)
     # code = Column(BigInteger, index=True, unique=True, nullable=False)
@@ -41,6 +41,7 @@ class ScheduleModel(Base, SerializerMixin):
     workflows, an alias was added to identify each instance, and is more
     friendly than jobid.
     :param name: name of the notebook file.
+    :param description: A friendly description of the purpose of this workflow
     :param job_detail: details of the execution. It is composed by two nested
     entities: ScheduleData and NBTask.
     :param enabled: if the task should run or not.
@@ -54,7 +55,8 @@ class ScheduleModel(Base, SerializerMixin):
     id = Column(Integer, primary_key=True)
     jobid = Column(String(24), index=True, unique=True)
     alias = Column(String(), index=True, unique=True, nullable=True)
-    name = Column(String(), nullable=False)
+    nb_name = Column(String(), nullable=False)
+    description = Column(String(), nullable=True)
     job_detail = Column(JSONB(), nullable=False)
     enabled = Column(Boolean, default=True, nullable=False)
 

--- a/nb_workflows/workflows/models.py
+++ b/nb_workflows/workflows/models.py
@@ -1,7 +1,7 @@
 # pylint: disable=too-few-public-methods
 from datetime import datetime
 
-from sqlalchemy import BigInteger, Boolean, Column, DateTime, Integer, String
+from sqlalchemy import BigInteger, Boolean, Column, DateTime, Integer, String, Float
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy_serializer import SerializerMixin
 
@@ -16,6 +16,7 @@ class HistoryModel(Base, SerializerMixin):
     :param taskid: is random id generated for each execution of the workflow
     :param name: the filename of the notebook executed
     :param result: is the result of the task. TaskResult
+    :param elapsed_secs: Time in seconds from the start of the task to the end.
     :param status: -1 fail, 0 ok.
     """
 
@@ -27,6 +28,7 @@ class HistoryModel(Base, SerializerMixin):
     executionid = Column(String(24))  # should be execution id
     nb_name = Column(String(), nullable=False)
     result = Column(JSONB(), nullable=False)
+    elapsed_secs = Column(Float(), nullable=False)
     status = Column(Integer, index=True)
     # code = Column(BigInteger, index=True, unique=True, nullable=False)
     created_at = Column(DateTime(), default=datetime.utcnow(), nullable=False)

--- a/nb_workflows/workflows/registers.py
+++ b/nb_workflows/workflows/registers.py
@@ -1,7 +1,6 @@
 from dataclasses import asdict
 
 from discord_webhook import DiscordWebhook
-
 from nb_workflows.conf import Config
 from nb_workflows.db.sync import SQL
 from nb_workflows.workflows.models import HistoryModel
@@ -30,10 +29,10 @@ def rq_job_ok(job, connection, result, *args, **kwargs):
 
     status = 0
     if result.error:
-        send_discord_error(msg=f"{result.taskid} failed. {result.error}")
+        send_discord_error(msg=f"{result.executionid} failed. {result.error}")
         status = -1
     row = HistoryModel(
-        taskid=job.id,
+        executionid=job.id,
         # jobid=result.alias,
         name=result.name,
         result=result_data,
@@ -54,7 +53,7 @@ def rq_job_error(job, connection, type, value, traceback):
     if job.params:
         name = job.params[0].get("name", name)
 
-    row = HistoryModel(taskid=job.id, name=name, result=data, status=-2)
+    row = HistoryModel(executionid=job.id, name=name, result=data, status=-2)
     session = db.sessionmaker()()
     session.add(row)
     session.commit()
@@ -63,23 +62,23 @@ def rq_job_error(job, connection, type, value, traceback):
     send_discord_error(msg=f"{job.id} failed. {name}")
 
 
-def job_history_register(task_result, nb_task):
+def job_history_register(execution_result, nb_task):
     """run inside of the nb_job_executor"""
     db = SQL(Config.SQL)
 
-    result_data = asdict(task_result)
+    result_data = asdict(execution_result)
 
     status = 0
-    if task_result.error:
+    if execution_result.error:
         status = -1
         send_discord_error(
-            msg=f"{task_result.taskid} failed. { task_result.name }"
+            msg=f"{execution_result.executionid} failed. { execution_result.name }"
         )
 
     row = HistoryModel(
-        taskid=task_result.taskid,
+        executionid=execution_result.executionid,
         jobid=nb_task.jobid,
-        name=task_result.name,
+        nb_name=execution_result.name,
         result=result_data,
         status=status,
     )
@@ -89,4 +88,4 @@ def job_history_register(task_result, nb_task):
     session.close()
 
     if nb_task.notificate and status == 0:
-        send_discord_ok(msg=f"{task_result.taskid} finished ok")
+        send_discord_ok(msg=f"{execution_result.executionid} finished ok")

--- a/nb_workflows/workflows/registers.py
+++ b/nb_workflows/workflows/registers.py
@@ -76,8 +76,9 @@ def job_history_register(execution_result, nb_task):
         )
 
     row = HistoryModel(
-        executionid=execution_result.executionid,
         jobid=nb_task.jobid,
+        executionid=execution_result.executionid,
+        elapsed_secs=execution_result.elapsed_secs,
         nb_name=execution_result.name,
         result=result_data,
         status=status,

--- a/nb_workflows/workflows/scheduler.py
+++ b/nb_workflows/workflows/scheduler.py
@@ -6,7 +6,8 @@ from typing import Any, Dict, List, Optional, Union
 from nb_workflows.conf import Config
 from nb_workflows.db.sync import SQL
 from nb_workflows.hashes import Hash96
-from nb_workflows.workflows.core import NBTask, nb_job_executor
+from nb_workflows.workflows.core import nb_job_executor
+from nb_workflows.workflows.entities import (NBTask, ScheduleData)
 from nb_workflows.workflows.models import ScheduleModel
 from redis import Redis
 from rq import Queue
@@ -14,45 +15,12 @@ from rq.job import Job
 from rq.registry import FailedJobRegistry, StartedJobRegistry
 from rq_scheduler import Scheduler
 from sqlalchemy import delete, select
+from sqlalchemy.exc import IntegrityError
+
+_DEFAULT_SCH_TASK_TO = 60 * 5  # 5 minutes
 
 
-@dataclass
-class ScheduleInterval:
-    task: NBTask
-    interval: int  # seconds
-    qname: str = "default"
-    alias: Optional[str] = None
-    start_in_min: int = 0
-    repeat: Optional[int] = None
-    enabled: bool = True
-
-
-@dataclass
-class ScheduleCron:
-    task: NBTask
-    cron: str
-    qname: str = "default"
-    alias: Optional[str] = None
-    start_in_min: int = 0
-    repeat: Optional[int] = None
-    enabled: bool = True
-
-
-@dataclass
-class ScheduleData:
-    """Used as generic structure when querying database"""
-
-    task: NBTask
-    qname: str = "default"
-    alias: Optional[str] = None
-    start_in_min: int = 0
-    repeat: Optional[int] = None
-    cron: Optional[str] = None
-    interval: Optional[str] = None
-    enabled: bool = True
-
-
-def get_job(session, jobid) -> Union[ScheduleModel, None]:
+def get_job_from_db(session, jobid) -> Union[ScheduleModel, None]:
     stmt = select(ScheduleModel).where(ScheduleModel.jobid == jobid)
     result = session.execute(stmt)
     row = result.scalar()
@@ -62,25 +30,7 @@ def get_job(session, jobid) -> Union[ScheduleModel, None]:
     return None
 
 
-def _parse_job_detail(data_dict) -> ScheduleData:
-    _task = NBTask(**data_dict["job_detail"]["task"])
-    s_data = ScheduleData(**data_dict["job_detail"])
-    s_data.task = _task
-    return s_data
-
-
-def get_and_parse_job(session, jobid) -> Union[ScheduleData, None]:
-    stmt = select(ScheduleModel).where(ScheduleModel.jobid == jobid)
-    result = session.execute(stmt)
-    row = result.scalar()
-
-    if row:
-        s_data = _parse_job_detail(row.to_dict())
-        return s_data
-    return None
-
-
-def scheduler_wrapper(jobid):
+def scheduler_dispatcher(jobid):
     """Because rq-scheduler has some limitations
     and could be abandoned in the future, this abstraction was created
     where the idea is to use the scheduler only to enqueue through rq.
@@ -96,26 +46,30 @@ def scheduler_wrapper(jobid):
     Session = db.sessionmaker()
 
     with Session() as session:
-        obj_model = get_job(session, jobid)
+        obj_model = get_job_from_db(session, jobid)
         if obj_model and obj_model.enabled:
             id_ = scheduler.executionid()
-            schedule_data = _parse_job_detail(obj_model.to_dict())
-            # setting jobid for the workflow_history table
-            schedule_data.task.jobid = jobid
+            task = NBTask(**obj_model.job_detail)
+            task.jobid = jobid
+            task.schedule = ScheduleData(**task.schedule)
             _job = Q.enqueue(
                 nb_job_executor,
-                schedule_data.task,
+                task,
                 job_id=id_,
-                job_timeout=schedule_data.task.timeout,
+                job_timeout=task.timeout,
             )
         else:
             if not obj_model:
-                raise IndexError(f"job: {jobid} not found")
-            else:
-                print(f"Job: {jobid} disabled")
+                scheduler.cancel(jobid)
+                print(f"job: {jobid} not found, deleted")
+                # raise IndexError(f"job: {jobid} not found")
+
+            print(f"Job: {jobid} disabled")
 
 
 class QueueExecutor:
+    """A thin wrapper over the Queue object of rq"""
+
     def __init__(self, redis, qname="default"):
         self.redis = Redis(**redis)
         self.Q = Queue(qname, connection=self.redis)
@@ -127,12 +81,28 @@ class QueueExecutor:
         # self.started = StartedJobRegistry(name=qname, connection=self.redis)
 
     def enqueue(self, f, *args, **kwargs) -> Job:
+        """ A wrapper over the Queue.enqueue() function of RQ lib
+        """
         job = self.Q.enqueue(
             f,
             # on_success=rq_job_ok,
             # on_failure=rq_job_error,
             *args,
             **kwargs,
+        )
+        return job
+
+    def enqueue_notebook(self, task: NBTask, executionid=None) -> Job:
+        """ Enqueue in redis a notebook workflow
+        :param task: NBTask object
+        :param executionid: An optional executionid
+        """
+        _id = executionid or SchedulerExecutor.executionid()
+        job = self.Q.enqueue(
+            nb_job_executor,
+            task,
+            job_id=_id,
+            job_timeout=task.timeout,
         )
         return job
 
@@ -179,32 +149,6 @@ class SchedulerExecutor:
         """
         return Hash96.time_random_string().id_hex
 
-    def _cron2redis(self, jobid: str, cron: ScheduleCron):
-        self.scheduler.cron(
-            cron.cron,
-            id=jobid,
-            func=nb_job_executor,
-            args=[cron.task],
-            repeat=cron.repeat,
-            queue_name=cron.qname,
-            # on_success=rq_job_ok,
-            # on_failure=rq_job_error,
-        )
-
-    def _interval2redis(self, jobid: str, interval: ScheduleInterval):
-        start_in_dt = datetime.utcnow() + timedelta(minutes=interval.start_in_min)
-
-        self.scheduler.schedule(
-            id=jobid,
-            scheduled_time=start_in_dt,
-            func=scheduler_wrapper,
-            args=[jobid],
-            interval=interval.interval,
-            repeat=interval.repeat,
-            queue_name=interval.qname,
-            timeout=60 * 5,  # 5 minutes
-        )
-
     async def get_jobid_db(self, session, jobid):
         stmt = select(ScheduleModel).where(ScheduleModel.jobid == jobid)
         result = await session.execute(stmt)
@@ -236,63 +180,59 @@ class SchedulerExecutor:
         rsp = await loop.run_in_executor(None, func, *args, **kwargs)
         return rsp
 
-    @staticmethod
-    def _parse_interval_dict(data_dict) -> ScheduleInterval:
-        _task = NBTask(**data_dict["task"])
-        interval = ScheduleInterval(**data_dict)
-        interval.task = _task
-        return interval
-
-    @staticmethod
-    def _parse_cron_dict(data_dict) -> ScheduleCron:
-        _task = NBTask(**data_dict["task"])
-        cron = ScheduleCron(**data_dict)
-        cron.task = _task
-        return cron
-
-    async def schedule(self, session, data_dict, jobid=None) -> str:
-        if data_dict.get("interval"):
-            j = await self.schedule_interval(session, data_dict, jobid)
-        else:
-            j = await self.schedule_cron(session, data_dict, jobid)
-
-        return j
-
-    async def schedule_cron(self, session, data_dict, jobid=None) -> str:
-        """Entrypoint to register the task in the scheduler and
-        register it in the database."""
-
-        jobid = jobid or self.jobid()
-
-        obj = self._parse_cron_dict(data_dict)
+    async def schedule(self, session, data_dict) -> str:
+        schedule_data = data_dict["schedule"]
+        task = NBTask(**data_dict)
+        task.schedule = ScheduleData(**schedule_data)
+        jobid = self.jobid()
 
         sch = ScheduleModel(
             jobid=jobid,
-            nb_name=obj.task.name,
-            alias=obj.alias,
+            nb_name=task.nb_name,
+            alias=task.schedule.alias,
             job_detail=data_dict,
-            enabled=obj.enabled,
+            enabled=task.schedule.enabled
         )
         session.add(sch)
-        await self.run_async(self._cron2redis, jobid, obj)
+        # check error
+        try:
+            await session.commit()
+        except IntegrityError:
+            raise KeyError("NB workflow already exist")
+
+        if task.schedule.cron:
+            await self.run_async(self._cron2redis, jobid, task)
+        else:
+            await self.run_async(self._interval2redis, jobid, task)
+
         return jobid
 
-    async def schedule_interval(self, session, data_dict, jobid=None) -> str:
-        """Entrypoint to register the task in the scheduler and
-        register it in the database."""
-        jobid = jobid or self.jobid()
-        obj = self._parse_interval_dict(data_dict)
+    def _interval2redis(self, jobid: str, task: NBTask):
+        interval = task.schedule
+        start_in_dt = datetime.utcnow() + timedelta(
+            minutes=interval.start_in_min)
 
-        sch = ScheduleModel(
-            jobid=jobid,
-            nb_name=obj.task.nb_name,
-            job_detail=data_dict,  # schedule_detail
-            alias=obj.alias,
-            enabled=obj.enabled,
+        self.scheduler.schedule(
+            id=jobid,
+            scheduled_time=start_in_dt,
+            func=scheduler_dispatcher,
+            args=[jobid],
+            interval=interval.interval,
+            repeat=interval.repeat,
+            queue_name=task.qname,
+            timeout=_DEFAULT_SCH_TASK_TO,
         )
-        session.add(sch)
-        await self.run_async(self._interval2redis, jobid, obj)
-        return jobid
+
+    def _cron2redis(self, jobid: str, task: NBTask):
+        cron = task.schedule
+        self.scheduler.cron(
+            cron.cron,
+            id=jobid,
+            func=scheduler_dispatcher,
+            args=[jobid],
+            repeat=cron.repeat,
+            queue_name=task.qname,
+        )
 
     def list_jobs(self):
         """List jobs from Redis"""

--- a/nb_workflows/workflows/web.py
+++ b/nb_workflows/workflows/web.py
@@ -6,12 +6,11 @@ from typing import List, Optional
 
 from nb_workflows.conf import Config
 from nb_workflows.utils import get_query_param, list_workflows, run_async
-from nb_workflows.workflows.core import NBTask, nb_job_executor
-from nb_workflows.workflows.scheduler import (QueueExecutor, ScheduleCron,
-                                              ScheduleInterval,
-                                              SchedulerExecutor,
-                                              scheduler_wrapper)
-from sanic import Blueprint, Sanic
+from nb_workflows.workflows.core import nb_job_executor
+from nb_workflows.workflows.entities import NBTask
+from nb_workflows.workflows.scheduler import (QueueExecutor, SchedulerExecutor,
+                                              scheduler_dispatcher)
+from sanic import Blueprint, Sanic, exceptions
 from sanic.response import json
 from sanic_ext import openapi
 
@@ -45,7 +44,6 @@ class JobDetail:
 @workflows_bp.listener("before_server_start")
 def startserver(current_app, loop):
     _cfg = Config.rq2dict()
-    # current_app.ctx.redis = SchedulerExecutor(_cfg)
     current_app.ctx.scheduler = SchedulerExecutor(_cfg)
     current_app.ctx.Q = QueueExecutor(_cfg)
     # current_app.ctx.queue = queue_init(_cfg)
@@ -53,7 +51,8 @@ def startserver(current_app, loop):
 
 @workflows_bp.post("/notebooks/_run")
 @openapi.body({"application/json": NBTask})
-@openapi.response(202, JobResponse, "Task executed")
+@openapi.response(202, {"executionid": str}, "Task executed")
+@openapi.response(400, {"msg": str}, "Wrong params")
 def launch_task(request):
     """
     Prepare and execute a Notebook Workflow Job based on a filename
@@ -61,20 +60,32 @@ def launch_task(request):
     The file should exist remotetly but it doesn't need to be
     previously scheduled
     """
-    current_app = Sanic.get_app("nb_workflows")
-    nb_task = NBTask(**request.json)
+    try:
+        nb_task = NBTask(**request.json)
+    except TypeError:
+        return json(dict(msg="wrong params"), 400)
 
-    executionid = SchedulerExecutor.executionid()
+    Q = _get_q_executor()
 
-    # job = Job.create(nb_job_executor, args=nb_task, id=jobid)
-    # current_app.ctx.Q.enqueue_job(job)
-    job = current_app.ctx.Q.enqueue(
-        nb_job_executor, nb_task, job_id=executionid, job_timeout=nb_task.timeout
-    )
-    return json(dict(jobid=job.id), status=202)
+    job = Q.enqueue_notebook(nb_task)
+
+    return json(dict(executionid=job.id), status=202)
 
 
-@workflows_bp.get("/notebooks/_fetch/<jobid>")
+@workflows_bp.get("/notebooks/_files")
+# @openapi.response(201, WorkflowTask, "Task executed")
+def list_nb_workflows(request):
+    """
+    List file workflows
+    """
+    # pylint: disable=unused-argument
+
+    nb_files = list_workflows()
+
+    return json(nb_files)
+
+
+@workflows_bp.get("/rqjobs/<jobid>")
 @openapi.parameter("jobid", str, "path")
 def get_job_result(request, jobid):
     """Get job result from the queue"""
@@ -94,9 +105,9 @@ def get_job_result(request, jobid):
     )
 
 
-@workflows_bp.get("/notebooks/failed")
+@workflows_bp.get("/rqjobs/failed")
 def get_failed_jobs(request):
-    """Get jobs failed"""
+    """Get jobs failed in RQ"""
     Q = _get_q_executor()
 
     jobs = Q.get_jobs_ids("failed")
@@ -104,7 +115,7 @@ def get_failed_jobs(request):
     return json(dict(rows=jobs, total=len(jobs)))
 
 
-@workflows_bp.delete("/notebooks/failed")
+@workflows_bp.delete("/rqjobs/failed")
 @openapi.parameter("remove", bool, "query")
 def delete_failed_jobs(request):
     """Remove failed jobs from the queue"""
@@ -117,9 +128,9 @@ def delete_failed_jobs(request):
     return json(dict(rows=jobs, total=len(jobs)))
 
 
-@workflows_bp.get("/notebooks/running")
+@workflows_bp.get("/rqjobs/running")
 def get_running_jobs(request):
-    """Get jobs failed"""
+    """Get jobs Running"""
     Q = _get_q_executor()
 
     jobs = Q.get_jobs_ids("started")
@@ -127,65 +138,9 @@ def get_running_jobs(request):
     return json(dict(rows=jobs, total=len(jobs)))
 
 
-@workflows_bp.get("/notebooks/_files")
-# @openapi.response(201, WorkflowTask, "Task executed")
-def list_nb_workflows(request):
-    """
-    List file workflows
-    """
-    # pylint: disable=unused-argument
-
-    nb_files = list_workflows()
-
-    return json(nb_files)
-
-
-@workflows_bp.post("/schedule/interval")
-@openapi.body({"application/json": ScheduleInterval})
-# @openapi.response(201, WorkflowTask, "Task Scheduled")
-async def schedule_interval(request):
-    """
-    Create and Schedule a workflow using interval syntax
-    """
-    # pylint: disable=not-a-mapping
-
-    scheduler = _get_scheduler()
-    session = request.ctx.session
-    alias = request.json.get("alias")
-    async with session.begin():
-        w = await scheduler.get_by_alias(session, alias)
-        if not w:
-            jobid = await scheduler.schedule_interval(session, request.json)
-            await session.commit()
-            return json(dict(jobid=jobid), 201)
-
-        return json(dict(jobid=w.jobid), 200)
-
-
-@workflows_bp.post("/schedule/cron")
-@openapi.body({"application/json": ScheduleCron})
-# @openapi.response(201, WorkflowTask, "Task Scheduled")
-async def schedule_cron(request):
-    """
-    Create and Schedule a workflow using CRON syntax
-    """
-    # pylint: disable=not-a-mapping
-    current_app = Sanic.get_app("nb_workflows")
-    jobid = SchedulerExecutor.jobid()
-    session = request.ctx.session
-    async with session.begin():
-        await current_app.ctx.scheduler.scheduler_cron(
-            jobid, session, request.json
-        )
-        await session.commit()
-
-    return json(dict(jobid=jobid), 201)
-    # return json(asdict(wt), 201)
-
-
 @workflows_bp.get("/schedule")
 # @openapi.response(200, List[JobDetail], "Task Scheduled")
-async def list_schedue(request):
+async def list_schedule(request):
     """List jobs registered in the database"""
     # pylint: disable=unused-argument
 
@@ -198,7 +153,7 @@ async def list_schedue(request):
     return json(result)
 
 
-@workflows_bp.get("/schedule/_redis")
+@workflows_bp.get("/schedule/rqjobs")
 @openapi.response(200, List[JobDetail], "Task Scheduled")
 def list_scheduled_redis(request):
     """
@@ -212,11 +167,40 @@ def list_scheduled_redis(request):
     return json(jobs, 200)
 
 
+@workflows_bp.post("/schedule")
+@openapi.body({"application/json": NBTask})
+@openapi.response(200, {"msg": str}, "Notebook Workflow already exist")
+@openapi.response(201, {"jobid": str}, "Notebook Workflow registered")
+@openapi.response(400, {"msg": str}, description="wrong params")
+async def create_notebook_schedule(request):
+    """
+    Register a notebook workflow and schedule it
+    """
+
+    try:
+        nb_task = NBTask(**request.json)
+        if not nb_task.schedule:
+            return json(dict(msg="schedule information is needed"), 400)
+    except TypeError:
+        return json(dict(msg="wrong params"), 400)
+
+    session = request.ctx.session
+    scheduler = _get_scheduler()
+
+    async with session.begin():
+        try:
+            rsp = await scheduler.schedule2(session, request.json)
+        except KeyError:
+            return json(dict(msg="notebook workflow already exists"),
+                        status=200)
+
+    return json(dict(jobid=rsp), status=201)
+
+
 @workflows_bp.delete("/schedule/<jobid>")
-# @openapi.body({"application/json": ScheduleCron})
 @openapi.parameter("jobid", str, "path")
 async def schedule_delete(request, jobid):
-    """delete a job from scheduler"""
+    """Delete a job from RQ and DB"""
     # pylint: disable=unused-argument
     scheduler = _get_scheduler()
     session = request.ctx.session
@@ -236,15 +220,15 @@ def schedule_run(request, jobid):
     """
     current_app = Sanic.get_app("nb_workflows")
 
-    job = current_app.ctx.Q.enqueue(scheduler_wrapper, jobid)
+    job = current_app.ctx.Q.enqueue(scheduler_dispatcher, jobid)
 
     return json(dict(jobid=job.id), status=202)
 
 
-@workflows_bp.delete("/schedule/_cancel/<jobid>")
+@workflows_bp.delete("/schedule/rqjobs/_cancel/<jobid>")
 @openapi.parameter("jobid", str, "path")
 async def schedule_cancel(request, jobid):
-    """delete a job from scheduler"""
+    """delete a scheduler job from redis"""
     # pylint: disable=unused-argument
 
     scheduler = _get_scheduler()
@@ -252,9 +236,7 @@ async def schedule_cancel(request, jobid):
     return json(dict(msg="done"), 200)
 
 
-@workflows_bp.delete("/schedule/_cancel_all")
-# @openapi.body({"application/json": ScheduleCron})
-# @openapi.parameter("jobid", str, "path")
+@workflows_bp.delete("/schedule/rqjobs/_cancel_all")
 async def schedule_cancel_all(request):
     """Cancel all the jobs in the queue"""
     # pylint: disable=unused-argument

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "nb_workflow"
 version = "0.1.0"
-description = ""
+description = "Schedule parameterized notebooks programmatically using cli or a REST API"
 authors = ["nuxion <nuxion@gmail.com>"]
 packages = [
    { include = "nb_workflows"},


### PR DESCRIPTION
The main goal of this refactor is that the library should provides an unique interface from the user perspective for the workflow configuration. 

This interface is `NBTask`. New configurations options should be put here. 

A second goal is the simplification of the naming of some entities and properties to avoid confusions and collisions. 

Changes made: 
- Entities simplified.
- A new module inside of workflows which has the main entities of the package
- `NBTask` is now the main interface from the user POV
- `SchedulerExecutor` simplified: the schedule method defines if the task is an interval task or a cron task
- web cli debug mode added
- If a nb workflow is deleted from db, it could be remains in the redis queue of the scheduler. In case of fail, it will be deleted from the queue
- elapsed_secs as seperate field in the table