### PR TITLE
Decouple redis instance from ClusterControl and cluster cli simplific…

### DIFF
--- a/nb_workflows/cluster/gcloud_provider.py
+++ b/nb_workflows/cluster/gcloud_provider.py
@@ -110,6 +110,9 @@ class GCEProvider(ProviderSpec):
             volumes = self._get_volumes_to_attach(non_boot)
 
         boot = self._create_boot_disk(node.volumes)
+        boot_name = None
+        if boot:
+            boot_name = boot.name
 
         tags = node.labels.get("tags")
         _labels = deepcopy(node.labels)
@@ -121,7 +124,7 @@ class GCEProvider(ProviderSpec):
             size=node.size,
             image=node.image,
             location=node.location,
-            ex_boot_disk=boot.name,
+            ex_boot_disk=boot_name,
             ex_network=node.network,
             ex_metadata=metadata,
             ex_tags=tags,

--- a/nb_workflows/conf/machines.yaml
+++ b/nb_workflows/conf/machines.yaml
@@ -44,6 +44,15 @@ machines:
       vcpus: 1
     volumes:
       - snapshot-base
+  gce-tiny-default:
+    name: tiny-cpu
+    desc: Tiny cpu machine for gce
+    provider: gce
+    location: "us-central1-c"
+    machine_type:
+      size: "e2-micro"
+      image: "debian-11-bullseye-v20220406"
+      vcpus: 1
   gce-tiny-cpu:
     name: tiny-cpu
     desc: Tiny cpu machine for gce
@@ -64,6 +73,18 @@ machines:
       vcpus: 2
     volumes:
       - gce-boot-small
+  gce-small-gpu:
+    name: gce-small-gpu
+    desc: It includes a nvidia-tesla-t4
+    provider: gce
+    location: us-east1-c
+    machine_type:
+      size: n1-standard-1
+      image: "debian-11-bullseye-v20220406"
+      vcpus: 1
+    volumes:
+      - gce-boot-small
+        # gpu:
   do-tiny-cpu:
     name: tiny-cpu
     desc: Tiny cpu machine for DO

--- a/nb_workflows/types/config.py
+++ b/nb_workflows/types/config.py
@@ -46,7 +46,7 @@ class ServerSettings(BaseSettings):
     AGENT_DATA_FOLDER: str = ".worker_data/"
     CLUSTER_SSH_KEY_USER: str = "op"
     CLUSTER_SSH_PUBLIC_KEY: Optional[str] = None
-    CLUSTER_SPEC: str = "scripts/clusters.yaml"
+    CLUSTER_SPEC: str = "scripts/local_clusters.yaml"
     AGENT_HOMEDIR: str = "/home/op"
     AGENT_ENV_FILE: str = ".env.dev.docker"
     AGENT_HEARTBEAT_CHECK: int = 60 * 5

--- a/scripts/gce_clusters.yaml
+++ b/scripts/gce_clusters.yaml
@@ -4,7 +4,8 @@ default_cluster: default
 clusters:
   default:
     name: default
-    machine: gce-tiny-cpu
+    #machine: gce-tiny-cpu
+    machine: gce-tiny-default
     provider: gce
     qnames:
       - "default"

--- a/scripts/local_clusters.yaml
+++ b/scripts/local_clusters.yaml
@@ -1,4 +1,5 @@
 ---
+default_cluster: local
 clusters:
   local:
     name: local

--- a/tests/clusters_test.yaml
+++ b/tests/clusters_test.yaml
@@ -1,5 +1,6 @@
 ---
 inventory: tests/machines_test.yaml
+default_cluster: local
 clusters:
   local:
     name: local

--- a/tests/test_cli_cluster.py
+++ b/tests/test_cli_cluster.py
@@ -34,7 +34,8 @@ def test_cli_cluster_machine_create(mocker: MockerFixture, redis):
     cc_mock.create_instance.return_value = m
 
     result = runner.invoke(
-        cluster.create_machinecli, ["--from-file", "tests/clusters_test.yaml", "local"]
+        cluster.create_machinecli,
+        ["--from-file", "tests/clusters_test.yaml", "-C", "local"],
     )
     assert result.exit_code == 0
 
@@ -43,7 +44,7 @@ def test_cli_cluster_machine_create_error(mocker: MockerFixture, redis):
     runner = CliRunner()
     result = runner.invoke(
         cluster.create_machinecli,
-        ["--from-file", "tests/clusters_test.yaml", "non-exist"],
+        ["--from-file", "tests/clusters_test.yaml", "-C", "non-exist"],
     )
     assert result.exit_code == -1
 

--- a/tests/test_cluster_control.py
+++ b/tests/test_cluster_control.py
@@ -1,6 +1,7 @@
 from nb_workflows.cluster import Inventory, ProviderSpec
 from nb_workflows.cluster.control import ClusterControl, apply_scale_items
 from nb_workflows.cluster.inventory import Inventory
+from nb_workflows.control_plane.register import AgentRegister
 from nb_workflows.types.cluster import (
     ClusterFile,
     ClusterPolicy,
@@ -53,7 +54,8 @@ def test_cluster_control_load():
 def test_cluster_control_init(redis):
     clusters = ClusterControl.load_cluster_file("tests/clusters_test.yaml")
     inventory = Inventory(clusters.inventory)
-    cc = ClusterControl(redis, clusters.clusters["local"], inventory)
+    are = AgentRegister(redis, "local")
+    cc = ClusterControl(are, clusters.clusters["local"], inventory)
     policy = cc.policy
 
     assert cc.cluster_name == "local"


### PR DESCRIPTION
…ation

- Redis is only used by AgentRegister, in the future AgentRegister could be an interface and be used for HTTP and Redis commns
- Cluster cli simplification given an unified interface: cluster is an optional parameter instead of an argument
- default_cluster param in ClusterSpec File
- option to use a CLUSTER_SPEC environment to avoit repeating -f argument in cluster cli